### PR TITLE
fix Twilio in-browser-call functionality using application_sid

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -57,7 +57,7 @@ GEM
     diff-lcs (1.2.5)
     erubis (2.7.0)
     execjs (2.7.0)
-    faraday (0.12.1)
+    faraday (0.13.1)
       multipart-post (>= 1.2, < 3)
     globalid (0.3.7)
       activesupport (>= 4.1.0)
@@ -156,7 +156,7 @@ GEM
     turbolinks (5.0.1)
       turbolinks-source (~> 5)
     turbolinks-source (5.0.0)
-    twilio-ruby (5.0.0.rc26)
+    twilio-ruby (5.0.0)
       faraday (~> 0.9)
       jwt (~> 1.5)
       libxml-ruby (= 3.0.0)
@@ -181,8 +181,8 @@ DEPENDENCIES
   sass-rails (~> 5.0)
   sqlite3
   turbolinks
-  twilio-ruby (~> 5.0.0.rc26)
+  twilio-ruby (~> 5.0.0)
   uglifier (>= 1.3.0)
 
 BUNDLED WITH
-   1.15.1
+   1.15.4

--- a/lib/twilio_capability.rb
+++ b/lib/twilio_capability.rb
@@ -4,17 +4,17 @@ class TwilioCapability
   def self.generate(role)
     # To find TWILIO_ACCOUNT_SID, TWILIO_AUTH_TOKEN visit
     # https://www.twilio.com/user/account
-    account_sid = ENV['TWILIO_ACCOUNT_SID']
-    auth_token  = ENV['TWILIO_AUTH_TOKEN']
+    account_sid     = ENV['TWILIO_ACCOUNT_SID']
+    auth_token      = ENV['TWILIO_AUTH_TOKEN']
+    application_sid = ENV['TWIML_APPLICATION_SID']
     # binding.pry
     capability = Twilio::JWT::ClientCapability.new(account_sid, auth_token)
-    outgoing_scope = Twilio::JWT::ClientCapability::OutgoingClientScope.new(account_sid, role)
+    outgoing_scope = Twilio::JWT::ClientCapability::OutgoingClientScope.new(application_sid, role)
     capability.add_scope outgoing_scope
 
     incoming_scope = Twilio::JWT::ClientCapability::IncomingClientScope.new(role)
     capability.add_scope incoming_scope
 
-    application_sid = ENV['TWIML_APPLICATION_SID']
 
     capability.to_s
   end


### PR DESCRIPTION
The code as it was wasn't working because the application_sid wasn't put in the proper place. This fix should take care of that! 